### PR TITLE
Support tuples for random_crystal

### DIFF
--- a/pyxtal/crystal.py
+++ b/pyxtal/crystal.py
@@ -404,6 +404,9 @@ class random_crystal:
             if isinstance(s, dict):
                 for key in s:
                     num += int(key[:-1])
+            elif isinstance(s, tuple):
+                (letter, x, y, z) = s
+                num += int(letter[:-1])
             else:
                 num += int(s[:-1])
         if numIon == num:


### PR DESCRIPTION
Bugfix for _check_consistency() for tuples, otherwise causes the following error: `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'tuple'`